### PR TITLE
implement julia function descriptor

### DIFF
--- a/src/ray/common/function_descriptor.cc
+++ b/src/ray/common/function_descriptor.cc
@@ -46,6 +46,18 @@ FunctionDescriptor FunctionDescriptorBuilder::BuildPython(
   return ray::FunctionDescriptor(new PythonFunctionDescriptor(std::move(descriptor)));
 }
 
+FunctionDescriptor FunctionDescriptorBuilder::BuildJulia(
+    const std::string &module_name,
+    const std::string &function_name,
+    const std::string &function_hash) {
+  rpc::FunctionDescriptor descriptor;
+  auto typed_descriptor = descriptor.mutable_julia_function_descriptor();
+  typed_descriptor->set_module_name(module_name);
+  typed_descriptor->set_function_name(function_name);
+  typed_descriptor->set_function_hash(function_hash);
+  return ray::FunctionDescriptor(new JuliaFunctionDescriptor(std::move(descriptor)));
+}
+
 FunctionDescriptor FunctionDescriptorBuilder::BuildCpp(const std::string &function_name,
                                                        const std::string &caller,
                                                        const std::string &class_name) {
@@ -65,6 +77,8 @@ FunctionDescriptor FunctionDescriptorBuilder::FromProto(rpc::FunctionDescriptor 
     return ray::FunctionDescriptor(new ray::PythonFunctionDescriptor(std::move(message)));
   case ray::FunctionDescriptorType::kCppFunctionDescriptor:
     return ray::FunctionDescriptor(new ray::CppFunctionDescriptor(std::move(message)));
+  case ray::FunctionDescriptorType::kJuliaFunctionDescriptor:
+    return ray::FunctionDescriptor(new ray::JuliaFunctionDescriptor(std::move(message)));
   default:
     break;
   }
@@ -96,6 +110,12 @@ FunctionDescriptor FunctionDescriptorBuilder::FromVector(
         function_descriptor_list[0],   // function name
         function_descriptor_list[1],   // caller
         function_descriptor_list[2]);  // class name
+  } else if (language == rpc::Language::JULIA) {
+    RAY_CHECK(function_descriptor_list.size() == 3);
+    return FunctionDescriptorBuilder::BuildJulia(
+        function_descriptor_list[0],   // module name
+        function_descriptor_list[1],   // function name
+        function_descriptor_list[2]);  // function hash
   } else {
     RAY_LOG(FATAL) << "Unspported language " << language;
     return FunctionDescriptorBuilder::Empty();

--- a/src/ray/common/function_descriptor.h
+++ b/src/ray/common/function_descriptor.h
@@ -230,7 +230,7 @@ class JuliaFunctionDescriptor : public FunctionDescriptorInterface {
       : FunctionDescriptorInterface(std::move(message)) {
     RAY_CHECK(message_->function_descriptor_case() ==
               ray::FunctionDescriptorType::kJuliaFunctionDescriptor);
-    typed_message_ = &(message_->python_function_descriptor());
+    typed_message_ = &(message_->julia_function_descriptor());
   }
 
   virtual size_t Hash() const {
@@ -269,6 +269,8 @@ class JuliaFunctionDescriptor : public FunctionDescriptorInterface {
     const std::string &function_name = typed_message_->function_name();
     return module_name.empty() ? function_name : module_name + "." + function_name;
   }
+
+  virtual std::string ClassName() const { return ""; }
 
   const std::string &ModuleName() const { return typed_message_->module_name(); }
 

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -26,6 +26,7 @@ enum Language {
   PYTHON = 0;
   JAVA = 1;
   CPP = 2;
+  JULIA = 3;
 }
 
 // Type of a worker.
@@ -114,12 +115,19 @@ message CppFunctionDescriptor {
   string class_name = 3;
 }
 
+message JuliaFunctionDescriptor {
+  string module_name = 1;
+  string function_name = 2;
+  string function_hash = 3;
+}
+
 // A union wrapper for various function descriptor types.
 message FunctionDescriptor {
   oneof function_descriptor {
     JavaFunctionDescriptor java_function_descriptor = 1;
     PythonFunctionDescriptor python_function_descriptor = 2;
     CppFunctionDescriptor cpp_function_descriptor = 3;
+    JuliaFunctionDescriptor julia_function_descriptor = 4;
   }
 }
 


### PR DESCRIPTION
- add `JULIA` to the language enum
- add julia function descriptor to protobufs
- add `JuliaFunctionDescriptor` class...
- ...with methods for constructing based on the other existing languages

I confirmed this works by adding a function to create a JuliaFunctionDescriptor and then print the string to the JLL wrapper:

```
std::string print_julia_function_descriptor(std::string module_name,
                                            std::string function_name,
                                            std::string function_hash)
{
  FunctionDescriptor my_func;
  my_func = FunctionDescriptorBuilder::BuildJulia(module_name, function_name, function_hash);
  return my_func->ToString();
}
```