### PR TITLE
Support Julia workers in Raylets

### DIFF
--- a/python/ray/_private/runtime_env/context.py
+++ b/python/ray/_private/runtime_env/context.py
@@ -62,6 +62,8 @@ class RuntimeEnvContext:
 
             class_path_args = ["-cp", ray_jars + ":" + str(":".join(local_java_jars))]
             passthrough_args = class_path_args + passthrough_args
+        elif language == Language.JULIA:
+            executable = "julia"
         elif sys.platform == "win32":
             executable = ""
         else:

--- a/python/ray/_private/runtime_env/context.py
+++ b/python/ray/_private/runtime_env/context.py
@@ -25,7 +25,7 @@ class RuntimeEnvContext:
         resources_dir: Optional[str] = None,
         container: Dict[str, Any] = None,
         java_jars: List[str] = None,
-        julia_executable: Option[str] = None,
+        julia_executable: Optional[str] = None,
     ):
         self.command_prefix = command_prefix or []
         self.env_vars = env_vars or {}

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1793,6 +1793,7 @@ def build_julia_worker_command(
     raylet_name: str,
     redis_password: str,
     session_dir: str,
+    log_dir: str,
     node_ip_address: str,
     setup_worker_path: str,
 ):
@@ -1813,7 +1814,7 @@ def build_julia_worker_command(
     """
 
     # TODO: --project, --startup-file=no, --banner=no, ...?
-     command = [
+    command = [
         sys.executable,
         setup_worker_path,
         DEFAULT_WORKER_EXECUTABLE,

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1521,6 +1521,7 @@ def start_raylet(
             raylet_name,
             redis_password,
             session_dir,
+            log_dir,
             node_ip_address,
             setup_worker_path,
         )

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1467,6 +1467,7 @@ def start_raylet(
         ["{},{}".format(*kv) for kv in static_resources.items()]
     )
 
+    # JAVA
     has_java_command = False
     if shutil.which("java") is not None:
         has_java_command = True
@@ -1493,6 +1494,7 @@ def start_raylet(
     else:
         java_worker_command = []
 
+    # CPP
     if os.path.exists(DEFAULT_WORKER_EXECUTABLE):
         cpp_worker_command = build_cpp_worker_command(
             gcs_address,
@@ -1506,6 +1508,24 @@ def start_raylet(
         )
     else:
         cpp_worker_command = []
+
+    # JULIA
+    has_julia_command = False
+    if shutil.which("julia") is not None:
+        has_julia_command = True
+    
+    if has_julia_command is True:
+        julia_worker_command = build_julia_worker_command(
+            gcs_address,
+            plasma_store_name,
+            raylet_name,
+            redis_password,
+            session_dir,
+            node_ip_address,
+            setup_worker_path,
+        )
+    else:
+        julia_worker_command = []
 
     # Create the command that the Raylet will use to start workers.
     # TODO(architkulkarni): Pipe in setup worker args separately instead of
@@ -1605,6 +1625,7 @@ def start_raylet(
         f"--python_worker_command={subprocess.list2cmdline(start_worker_command)}",  # noqa
         f"--java_worker_command={subprocess.list2cmdline(java_worker_command)}",  # noqa
         f"--cpp_worker_command={subprocess.list2cmdline(cpp_worker_command)}",  # noqa
+        f"--julia_worker_command={subprocess.list2cmdline(julia_worker_command)}",  # noqa
         f"--native_library_path={DEFAULT_NATIVE_LIBRARY_PATH}",
         f"--temp_dir={temp_dir}",
         f"--session_dir={session_dir}",
@@ -1750,6 +1771,49 @@ def build_cpp_worker_command(
     """
 
     command = [
+        sys.executable,
+        setup_worker_path,
+        DEFAULT_WORKER_EXECUTABLE,
+        f"--ray_plasma_store_socket_name={plasma_store_name}",
+        f"--ray_raylet_socket_name={raylet_name}",
+        "--ray_node_manager_port=RAY_NODE_MANAGER_PORT_PLACEHOLDER",
+        f"--ray_address={bootstrap_address}",
+        f"--ray_redis_password={redis_password}",
+        f"--ray_session_dir={session_dir}",
+        f"--ray_logs_dir={log_dir}",
+        f"--ray_node_ip_address={node_ip_address}",
+        "RAY_WORKER_DYNAMIC_OPTION_PLACEHOLDER",
+    ]
+
+    return command
+
+def build_julia_worker_command(
+    bootstrap_address: str,
+    plasma_store_name: str,
+    raylet_name: str,
+    redis_password: str,
+    session_dir: str,
+    node_ip_address: str,
+    setup_worker_path: str,
+):
+    """This method assembles the command used to start a Julia worker.
+
+    Args:
+        bootstrap_address: Bootstrap address of ray cluster.
+        plasma_store_name: The name of the plasma store socket to connect
+           to.
+        raylet_name: The name of the raylet socket to create.
+        redis_password: The password of connect to redis.
+        session_dir: The path of this session.
+        node_ip_address: The ip address for this node.
+        setup_worker_path: The path of the Python file that will set up
+            the environment for the worker process.
+    Returns:
+        The command string for starting Julia worker.
+    """
+
+    # TODO: --project, --startup-file=no, --banner=no, ...?
+     command = [
         sys.executable,
         setup_worker_path,
         DEFAULT_WORKER_EXECUTABLE,

--- a/src/ray/common/function_descriptor.h
+++ b/src/ray/common/function_descriptor.h
@@ -358,6 +358,9 @@ inline bool operator==(const FunctionDescriptor &left, const FunctionDescriptor 
   case ray::FunctionDescriptorType::kCppFunctionDescriptor:
     return static_cast<const CppFunctionDescriptor &>(*left) ==
            static_cast<const CppFunctionDescriptor &>(*right);
+  case ray::FunctionDescriptorType::kJuliaFunctionDescriptor:
+    return static_cast<const JuliaFunctionDescriptor &>(*left) ==
+           static_cast<const JuliaFunctionDescriptor &>(*right);
   default:
     RAY_LOG(FATAL) << "Unknown function descriptor type: " << left->Type();
     return false;

--- a/src/ray/core_worker/common.cc
+++ b/src/ray/core_worker/common.cc
@@ -39,6 +39,8 @@ std::string LanguageString(Language language) {
     return "java";
   } else if (language == Language::CPP) {
     return "cpp";
+  } else if (language == Language::JULIA) {
+    return "julia";
   }
   RAY_CHECK(false);
   return "";

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -50,6 +50,7 @@ DEFINE_int32(maximum_startup_concurrency, 1, "Maximum startup concurrency.");
 DEFINE_string(static_resource_list, "", "The static resource list of this node.");
 DEFINE_string(python_worker_command, "", "Python worker command.");
 DEFINE_string(java_worker_command, "", "Java worker command.");
+DEFINE_string(julia_worker_command, "", "Julia worker command.");
 DEFINE_string(agent_command, "", "Dashboard agent command.");
 DEFINE_string(cpp_worker_command, "", "CPP worker command.");
 DEFINE_string(native_library_path,
@@ -104,6 +105,7 @@ int main(int argc, char *argv[]) {
   const std::string static_resource_list = FLAGS_static_resource_list;
   const std::string python_worker_command = FLAGS_python_worker_command;
   const std::string java_worker_command = FLAGS_java_worker_command;
+  const std::string julia_worker_command = FLAGS_julia_worker_command;
   const std::string agent_command = FLAGS_agent_command;
   const std::string cpp_worker_command = FLAGS_cpp_worker_command;
   const std::string native_library_path = FLAGS_native_library_path;
@@ -197,10 +199,14 @@ int main(int argc, char *argv[]) {
           node_manager_config.worker_commands.emplace(
               make_pair(ray::Language::CPP, ParseCommandLine(cpp_worker_command)));
         }
+        if (!julia_worker_command.empty()) {
+          node_manager_config.worker_commands.emplace(
+              make_pair(ray::Language::JULIA, ParseCommandLine(julia_worker_command)));
+        }
         node_manager_config.native_library_path = native_library_path;
         if (python_worker_command.empty() && java_worker_command.empty() &&
-            cpp_worker_command.empty()) {
-          RAY_LOG(FATAL) << "At least one of Python/Java/CPP worker command "
+            cpp_worker_command.empty() && julia_worker_command.empty()) {
+          RAY_LOG(FATAL) << "At least one of Python/Java/CPP/Julia worker command "
                          << "should be provided";
         }
         if (!agent_command.empty()) {

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -284,7 +284,6 @@ WorkerPool::BuildProcessCommandArgs(const Language &language,
                       std::to_string(runtime_env_hash));
   }
 
-  // TODO: Append user-defined per-job options for JULIA here??
 
   // Append user-defined per-process options here
   options.insert(options.end(), dynamic_options.begin(), dynamic_options.end());

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -241,7 +241,7 @@ WorkerPool::BuildProcessCommandArgs(const Language &language,
 
   // Append Ray-defined per-job options here
   std::string code_search_path;
-  if (language == Language::JAVA || language == Language::CPP) {
+  if (language == Language::JAVA || language == Language::CPP || language == Language::JULIA) {
     if (job_config) {
       std::string code_search_path_str;
       for (int i = 0; i < job_config->code_search_path_size(); i++) {
@@ -256,6 +256,8 @@ WorkerPool::BuildProcessCommandArgs(const Language &language,
         if (language == Language::JAVA) {
           code_search_path_str = "-Dray.job.code-search-path=" + code_search_path_str;
         } else if (language == Language::CPP) {
+          code_search_path_str = "--ray_code_search_path=" + code_search_path_str;
+        } else if (language == Language::JULIA) {
           code_search_path_str = "--ray_code_search_path=" + code_search_path_str;
         } else {
           RAY_LOG(FATAL) << "Unknown language " << Language_Name(language);
@@ -281,6 +283,8 @@ WorkerPool::BuildProcessCommandArgs(const Language &language,
     options.push_back("-Dray.internal.runtime-env-hash=" +
                       std::to_string(runtime_env_hash));
   }
+
+  // TODO: Append user-defined per-job options for JULIA here??
 
   // Append user-defined per-process options here
   options.insert(options.end(), dynamic_options.begin(), dynamic_options.end());
@@ -827,7 +831,10 @@ Status WorkerPool::RegisterDriver(const std::shared_ptr<WorkerInterface> &driver
   const auto job_id = driver->GetAssignedJobId();
   HandleJobStarted(job_id, job_config);
 
-  if (driver->GetLanguage() == Language::JAVA) {
+  // TODO do we want to support PrestartWorkers in Julia? Might cut down on runtime overhead...
+  if (driver->GetLanguage() == Language::JAVA || driver->GetLanguage() == Language::JULIA) {
+    send_reply_callback(Status::OK(), port);
+  } else if (driver->GetLanguage() == Language::JULIA) { // TODO check what send_reply_callback does
     send_reply_callback(Status::OK(), port);
   } else {
     if (!first_job_registered_ && RayConfig::instance().prestart_worker_first_driver() &&

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -833,7 +833,7 @@ Status WorkerPool::RegisterDriver(const std::shared_ptr<WorkerInterface> &driver
 
   if (driver->GetLanguage() == Language::JAVA) {
     send_reply_callback(Status::OK(), port);
-  } else if (driver->GetLanguage() == Language::JULIA) { // TODO check what send_reply_callback does
+  } else if (driver->GetLanguage() == Language::JULIA) {
     send_reply_callback(Status::OK(), port);
   } else {
     if (!first_job_registered_ && RayConfig::instance().prestart_worker_first_driver() &&

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -831,8 +831,7 @@ Status WorkerPool::RegisterDriver(const std::shared_ptr<WorkerInterface> &driver
   const auto job_id = driver->GetAssignedJobId();
   HandleJobStarted(job_id, job_config);
 
-  // TODO do we want to support PrestartWorkers in Julia? Might cut down on runtime overhead...
-  if (driver->GetLanguage() == Language::JAVA || driver->GetLanguage() == Language::JULIA) {
+  if (driver->GetLanguage() == Language::JAVA) {
     send_reply_callback(Status::OK(), port);
   } else if (driver->GetLanguage() == Language::JULIA) { // TODO check what send_reply_callback does
     send_reply_callback(Status::OK(), port);

--- a/src/ray/raylet/worker_pool_test.cc
+++ b/src/ray/raylet/worker_pool_test.cc
@@ -38,7 +38,7 @@ JobID JOB_ID2 = JobID::FromInt(2);
 std::string BAD_RUNTIME_ENV = "bad runtime env";
 const std::string BAD_RUNTIME_ENV_ERROR_MSG = "bad runtime env";
 
-std::vector<Language> LANGUAGES = {Language::PYTHON, Language::JAVA};
+std::vector<Language> LANGUAGES = {Language::PYTHON, Language::JULIA};
 
 class MockWorkerClient : public rpc::CoreWorkerClientInterface {
  public:
@@ -306,7 +306,7 @@ class WorkerPoolMock : public WorkerPool {
       auto pushed_it = pushedProcesses_.find(it->first);
       if (pushed_it == pushedProcesses_.end()) {
         int runtime_env_hash = 0;
-        bool is_java = false;
+        bool is_julia = false;
         // Parses runtime env hash to make sure the pushed workers can be popped out.
         for (auto command_args : it->second) {
           std::string runtime_env_key = "--runtime-env-hash=";
@@ -315,9 +315,9 @@ class WorkerPoolMock : public WorkerPool {
             runtime_env_hash =
                 std::stoi(command_args.substr(pos + runtime_env_key.size()));
           }
-          pos = command_args.find("java");
+          pos = command_args.find("julia");
           if (pos != std::string::npos) {
-            is_java = true;
+            is_julia = true;
           }
         }
         // TODO(SongGuyang): support C++ language workers.
@@ -328,7 +328,7 @@ class WorkerPoolMock : public WorkerPool {
         for (int i = 0; i < register_workers; i++) {
           auto worker = CreateWorker(
               it->first,
-              is_java ? Language::JAVA : Language::PYTHON,
+              is_julia ? Language::JULIA : Language::PYTHON,
               JOB_ID,
               rpc::WorkerType::WORKER,
               runtime_env_hash,
@@ -409,8 +409,8 @@ class WorkerPoolTest : public ::testing::Test {
         std::to_string(MAX_IO_WORKER_SIZE) + R"(, "kill_idle_workers_interval_ms": 0)" +
         R"(, "enable_worker_prestart": true)" + "}");
     SetWorkerCommands({{Language::PYTHON, {"dummy_py_worker_command"}},
-                       {Language::JAVA,
-                        {"java", "RAY_WORKER_DYNAMIC_OPTION_PLACEHOLDER", "MainClass"}}});
+                       {Language::JULIA,
+                        {"julia", "RAY_WORKER_DYNAMIC_OPTION_PLACEHOLDER", "MainClass"}}});
     std::promise<bool> promise;
     thread_io_service_.reset(new std::thread([this, &promise] {
       std::unique_ptr<boost::asio::io_service::work> work(
@@ -594,9 +594,9 @@ TEST_F(WorkerPoolDriverRegisteredTest, CompareWorkerProcessObjects) {
 TEST_F(WorkerPoolDriverRegisteredTest, HandleWorkerRegistration) {
   PopWorkerStatus status;
   auto [proc, token] = worker_pool_->StartWorkerProcess(
-      Language::JAVA, rpc::WorkerType::WORKER, JOB_ID, &status);
+      Language::JULIA, rpc::WorkerType::WORKER, JOB_ID, &status);
   std::vector<std::shared_ptr<WorkerInterface>> workers;
-  workers.push_back(worker_pool_->CreateWorker(Process(), Language::JAVA));
+  workers.push_back(worker_pool_->CreateWorker(Process(), Language::JULIA));
   for (const auto &worker : workers) {
     // Check that there's still a starting worker process
     // before all workers have been registered
@@ -645,8 +645,8 @@ TEST_F(WorkerPoolDriverRegisteredTest, StartupPythonWorkerProcessCount) {
   TestStartupWorkerProcessCount(Language::PYTHON, 1);
 }
 
-TEST_F(WorkerPoolDriverRegisteredTest, StartupJavaWorkerProcessCount) {
-  TestStartupWorkerProcessCount(Language::JAVA, 1);
+TEST_F(WorkerPoolDriverRegisteredTest, StartupJuliaWorkerProcessCount) {
+  TestStartupWorkerProcessCount(Language::JULIA, 1);
 }
 
 TEST_F(WorkerPoolDriverRegisteredTest, InitialWorkerProcessCount) {
@@ -699,64 +699,64 @@ TEST_F(WorkerPoolDriverRegisteredTest, PopWorkerSyncsOfMultipleLanguages) {
   auto py_worker =
       worker_pool_->CreateWorker(Process::CreateNewDummy(), Language::PYTHON);
   worker_pool_->PushWorker(py_worker);
-  // Check that the Python worker will not be popped if the given task is a Java task
-  const auto java_task_spec = ExampleTaskSpec(ActorID::Nil(), Language::JAVA);
-  ASSERT_NE(worker_pool_->PopWorkerSync(java_task_spec), py_worker);
+  // Check that the Python worker will not be popped if the given task is a Julia task
+  const auto julia_task_spec = ExampleTaskSpec(ActorID::Nil(), Language::JULIA);
+  ASSERT_NE(worker_pool_->PopWorkerSync(julia_task_spec), py_worker);
   // Check that the Python worker can be popped if the given task is a Python task
   const auto py_task_spec = ExampleTaskSpec(ActorID::Nil(), Language::PYTHON);
   ASSERT_EQ(worker_pool_->PopWorkerSync(py_task_spec), py_worker);
 
-  // Create a Java Worker, and add it to the pool
-  auto java_worker =
-      worker_pool_->CreateWorker(Process::CreateNewDummy(), Language::JAVA);
-  worker_pool_->PushWorker(java_worker);
-  // Check that the Java worker will be popped now for Java task
-  ASSERT_EQ(worker_pool_->PopWorkerSync(java_task_spec), java_worker);
+  // Create a Julia Worker, and add it to the pool
+  auto julia_worker =
+      worker_pool_->CreateWorker(Process::CreateNewDummy(), Language::JULIA);
+  worker_pool_->PushWorker(julia_worker);
+  // Check that the Julia worker will be popped now for Julia task
+  ASSERT_EQ(worker_pool_->PopWorkerSync(julia_task_spec), julia_worker);
 }
 
 TEST_F(WorkerPoolDriverRegisteredTest, StartWorkerWithDynamicOptionsCommand) {
   std::vector<std::string> actor_jvm_options;
-  actor_jvm_options.insert(
-      actor_jvm_options.end(),
-      {"-Dmy-actor.hello=foo", "-Dmy-actor.world=bar", "-Xmx2g", "-Xms1g"});
+  // actor_jvm_options.insert(
+  //     actor_jvm_options.end(),
+  //     {"-Dmy-actor.hello=foo", "-Dmy-actor.world=bar", "-Xmx2g", "-Xms1g"});
   JobID job_id = JobID::FromInt(12345);
   auto task_id = TaskID::ForDriverTask(job_id);
   auto actor_id = ActorID::Of(job_id, task_id, 1);
   TaskSpecification task_spec = ExampleTaskSpec(
-      ActorID::Nil(), Language::JAVA, job_id, actor_id, actor_jvm_options, task_id);
+      ActorID::Nil(), Language::JULIA, job_id, actor_id, actor_jvm_options, task_id);
 
   rpc::JobConfig job_config = rpc::JobConfig();
-  job_config.add_code_search_path("/test/code_search_path");
-  job_config.add_jvm_options("-Xmx1g");
-  job_config.add_jvm_options("-Xms500m");
-  job_config.add_jvm_options("-Dmy-job.hello=world");
-  job_config.add_jvm_options("-Dmy-job.foo=bar");
+  // job_config.add_code_search_path("/test/code_search_path");
+  // job_config.add_jvm_options("-Xmx1g");
+  // job_config.add_jvm_options("-Xms500m");
+  // job_config.add_jvm_options("-Dmy-job.hello=world");
+  // job_config.add_jvm_options("-Dmy-job.foo=bar");
   worker_pool_->HandleJobStarted(job_id, job_config);
 
   ASSERT_NE(worker_pool_->PopWorkerSync(task_spec), nullptr);
   const auto real_command =
       worker_pool_->GetWorkerCommand(worker_pool_->LastStartedWorkerProcess());
 
-  // NOTE: When adding a new parameter to Java worker command, think carefully about the
+  // NOTE: When adding a new parameter to Julia worker command, think carefully about the
   // position of this new parameter. Do not modify the order of existing parameters.
   std::vector<std::string> expected_command;
-  expected_command.push_back("java");
+  expected_command.push_back("julia");
   // Ray-defined per-job options
-  expected_command.insert(expected_command.end(),
-                          {"-Dray.job.code-search-path=/test/code_search_path"});
+  // expected_command.insert(expected_command.end(),
+  //                         {"--ray.job.code-search-path=/test/code_search_path"});
   // User-defined per-job options
-  expected_command.insert(
-      expected_command.end(),
-      {"-Xmx1g", "-Xms500m", "-Dmy-job.hello=world", "-Dmy-job.foo=bar"});
+  // expected_command.insert(
+  //     expected_command.end(),
+  //     {"-Xmx1g", "-Xms500m", "-Dmy-job.hello=world", "-Dmy-job.foo=bar"});
   // Ray-defined per-process options
-  expected_command.push_back("-Dray.raylet.startup-token=0");
-  expected_command.push_back("-Dray.internal.runtime-env-hash=1");
+  // expected_command.push_back("-Dray.raylet.startup-token=0");
+  // expected_command.push_back("-Dray.internal.runtime-env-hash=1");
   // User-defined per-process options
-  expected_command.insert(
-      expected_command.end(), actor_jvm_options.begin(), actor_jvm_options.end());
+  // expected_command.insert(
+  //     expected_command.end(), actor_jvm_options.begin(), actor_jvm_options.end());
   // Entry point
   expected_command.push_back("MainClass");
-  expected_command.push_back("--language=JAVA");
+  expected_command.push_back("--language=JULIA");
   ASSERT_EQ(real_command, expected_command);
   worker_pool_->HandleJobFinished(job_id);
 }
@@ -1383,10 +1383,10 @@ TEST_F(WorkerPoolDriverRegisteredTest, TestWorkerCappingWithExitDelay) {
   ///
 
   ///
-  /// Register some idle Python and Java (w/ multi-worker enabled) workers
+  /// Register some idle Python and Julia (w/ multi-worker enabled) workers
   ///
   std::vector<std::shared_ptr<WorkerInterface>> workers;
-  std::vector<Language> languages({Language::PYTHON, Language::JAVA});
+  std::vector<Language> languages({Language::PYTHON, Language::JULIA});
   for (int i = 0; i < POOL_SIZE_SOFT_LIMIT * 2; i++) {
     for (const auto &language : languages) {
       PopWorkerStatus status;
@@ -2098,9 +2098,9 @@ TEST_F(WorkerPoolTest, RegisterSecondPythonDriverCallbackImmediately) {
   ASSERT_TRUE(callback_called);
 }
 
-TEST_F(WorkerPoolTest, RegisterFirstJavaDriverCallbackImmediately) {
+TEST_F(WorkerPoolTest, RegisterFirstJuliaDriverCallbackImmediately) {
   auto driver =
-      worker_pool_->CreateWorker(Process::CreateNewDummy(), Language::JAVA, JOB_ID);
+      worker_pool_->CreateWorker(Process::CreateNewDummy(), Language::JULIA, JOB_ID);
 
   driver->AssignTaskId(TaskID::ForDriverTask(JOB_ID));
   bool callback_called = false;

--- a/src/ray/raylet/worker_pool_test.cc
+++ b/src/ray/raylet/worker_pool_test.cc
@@ -38,7 +38,7 @@ JobID JOB_ID2 = JobID::FromInt(2);
 std::string BAD_RUNTIME_ENV = "bad runtime env";
 const std::string BAD_RUNTIME_ENV_ERROR_MSG = "bad runtime env";
 
-std::vector<Language> LANGUAGES = {Language::PYTHON, Language::JULIA};
+std::vector<Language> LANGUAGES = {Language::PYTHON, Language::JAVA};
 
 class MockWorkerClient : public rpc::CoreWorkerClientInterface {
  public:
@@ -306,7 +306,7 @@ class WorkerPoolMock : public WorkerPool {
       auto pushed_it = pushedProcesses_.find(it->first);
       if (pushed_it == pushedProcesses_.end()) {
         int runtime_env_hash = 0;
-        bool is_julia = false;
+        bool is_java = false;
         // Parses runtime env hash to make sure the pushed workers can be popped out.
         for (auto command_args : it->second) {
           std::string runtime_env_key = "--runtime-env-hash=";
@@ -315,9 +315,9 @@ class WorkerPoolMock : public WorkerPool {
             runtime_env_hash =
                 std::stoi(command_args.substr(pos + runtime_env_key.size()));
           }
-          pos = command_args.find("julia");
+          pos = command_args.find("java");
           if (pos != std::string::npos) {
-            is_julia = true;
+            is_java = true;
           }
         }
         // TODO(SongGuyang): support C++ language workers.
@@ -328,7 +328,7 @@ class WorkerPoolMock : public WorkerPool {
         for (int i = 0; i < register_workers; i++) {
           auto worker = CreateWorker(
               it->first,
-              is_julia ? Language::JULIA : Language::PYTHON,
+              is_java ? Language::JAVA : Language::PYTHON,
               JOB_ID,
               rpc::WorkerType::WORKER,
               runtime_env_hash,
@@ -409,8 +409,8 @@ class WorkerPoolTest : public ::testing::Test {
         std::to_string(MAX_IO_WORKER_SIZE) + R"(, "kill_idle_workers_interval_ms": 0)" +
         R"(, "enable_worker_prestart": true)" + "}");
     SetWorkerCommands({{Language::PYTHON, {"dummy_py_worker_command"}},
-                       {Language::JULIA,
-                        {"julia", "RAY_WORKER_DYNAMIC_OPTION_PLACEHOLDER", "MainClass"}}});
+                       {Language::JAVA,
+                        {"java", "RAY_WORKER_DYNAMIC_OPTION_PLACEHOLDER", "MainClass"}}});
     std::promise<bool> promise;
     thread_io_service_.reset(new std::thread([this, &promise] {
       std::unique_ptr<boost::asio::io_service::work> work(
@@ -594,9 +594,9 @@ TEST_F(WorkerPoolDriverRegisteredTest, CompareWorkerProcessObjects) {
 TEST_F(WorkerPoolDriverRegisteredTest, HandleWorkerRegistration) {
   PopWorkerStatus status;
   auto [proc, token] = worker_pool_->StartWorkerProcess(
-      Language::JULIA, rpc::WorkerType::WORKER, JOB_ID, &status);
+      Language::JAVA, rpc::WorkerType::WORKER, JOB_ID, &status);
   std::vector<std::shared_ptr<WorkerInterface>> workers;
-  workers.push_back(worker_pool_->CreateWorker(Process(), Language::JULIA));
+  workers.push_back(worker_pool_->CreateWorker(Process(), Language::JAVA));
   for (const auto &worker : workers) {
     // Check that there's still a starting worker process
     // before all workers have been registered
@@ -645,8 +645,8 @@ TEST_F(WorkerPoolDriverRegisteredTest, StartupPythonWorkerProcessCount) {
   TestStartupWorkerProcessCount(Language::PYTHON, 1);
 }
 
-TEST_F(WorkerPoolDriverRegisteredTest, StartupJuliaWorkerProcessCount) {
-  TestStartupWorkerProcessCount(Language::JULIA, 1);
+TEST_F(WorkerPoolDriverRegisteredTest, StartupJavaWorkerProcessCount) {
+  TestStartupWorkerProcessCount(Language::JAVA, 1);
 }
 
 TEST_F(WorkerPoolDriverRegisteredTest, InitialWorkerProcessCount) {
@@ -699,64 +699,64 @@ TEST_F(WorkerPoolDriverRegisteredTest, PopWorkerSyncsOfMultipleLanguages) {
   auto py_worker =
       worker_pool_->CreateWorker(Process::CreateNewDummy(), Language::PYTHON);
   worker_pool_->PushWorker(py_worker);
-  // Check that the Python worker will not be popped if the given task is a Julia task
-  const auto julia_task_spec = ExampleTaskSpec(ActorID::Nil(), Language::JULIA);
-  ASSERT_NE(worker_pool_->PopWorkerSync(julia_task_spec), py_worker);
+  // Check that the Python worker will not be popped if the given task is a Java task
+  const auto java_task_spec = ExampleTaskSpec(ActorID::Nil(), Language::JAVA);
+  ASSERT_NE(worker_pool_->PopWorkerSync(java_task_spec), py_worker);
   // Check that the Python worker can be popped if the given task is a Python task
   const auto py_task_spec = ExampleTaskSpec(ActorID::Nil(), Language::PYTHON);
   ASSERT_EQ(worker_pool_->PopWorkerSync(py_task_spec), py_worker);
 
-  // Create a Julia Worker, and add it to the pool
-  auto julia_worker =
-      worker_pool_->CreateWorker(Process::CreateNewDummy(), Language::JULIA);
-  worker_pool_->PushWorker(julia_worker);
-  // Check that the Julia worker will be popped now for Julia task
-  ASSERT_EQ(worker_pool_->PopWorkerSync(julia_task_spec), julia_worker);
+  // Create a Java Worker, and add it to the pool
+  auto java_worker =
+      worker_pool_->CreateWorker(Process::CreateNewDummy(), Language::JAVA);
+  worker_pool_->PushWorker(java_worker);
+  // Check that the Java worker will be popped now for Java task
+  ASSERT_EQ(worker_pool_->PopWorkerSync(java_task_spec), java_worker);
 }
 
 TEST_F(WorkerPoolDriverRegisteredTest, StartWorkerWithDynamicOptionsCommand) {
   std::vector<std::string> actor_jvm_options;
-  // actor_jvm_options.insert(
-  //     actor_jvm_options.end(),
-  //     {"-Dmy-actor.hello=foo", "-Dmy-actor.world=bar", "-Xmx2g", "-Xms1g"});
+  actor_jvm_options.insert(
+      actor_jvm_options.end(),
+      {"-Dmy-actor.hello=foo", "-Dmy-actor.world=bar", "-Xmx2g", "-Xms1g"});
   JobID job_id = JobID::FromInt(12345);
   auto task_id = TaskID::ForDriverTask(job_id);
   auto actor_id = ActorID::Of(job_id, task_id, 1);
   TaskSpecification task_spec = ExampleTaskSpec(
-      ActorID::Nil(), Language::JULIA, job_id, actor_id, actor_jvm_options, task_id);
+      ActorID::Nil(), Language::JAVA, job_id, actor_id, actor_jvm_options, task_id);
 
   rpc::JobConfig job_config = rpc::JobConfig();
-  // job_config.add_code_search_path("/test/code_search_path");
-  // job_config.add_jvm_options("-Xmx1g");
-  // job_config.add_jvm_options("-Xms500m");
-  // job_config.add_jvm_options("-Dmy-job.hello=world");
-  // job_config.add_jvm_options("-Dmy-job.foo=bar");
+  job_config.add_code_search_path("/test/code_search_path");
+  job_config.add_jvm_options("-Xmx1g");
+  job_config.add_jvm_options("-Xms500m");
+  job_config.add_jvm_options("-Dmy-job.hello=world");
+  job_config.add_jvm_options("-Dmy-job.foo=bar");
   worker_pool_->HandleJobStarted(job_id, job_config);
 
   ASSERT_NE(worker_pool_->PopWorkerSync(task_spec), nullptr);
   const auto real_command =
       worker_pool_->GetWorkerCommand(worker_pool_->LastStartedWorkerProcess());
 
-  // NOTE: When adding a new parameter to Julia worker command, think carefully about the
+  // NOTE: When adding a new parameter to Java worker command, think carefully about the
   // position of this new parameter. Do not modify the order of existing parameters.
   std::vector<std::string> expected_command;
-  expected_command.push_back("julia");
+  expected_command.push_back("java");
   // Ray-defined per-job options
-  // expected_command.insert(expected_command.end(),
-  //                         {"--ray.job.code-search-path=/test/code_search_path"});
+  expected_command.insert(expected_command.end(),
+                          {"-Dray.job.code-search-path=/test/code_search_path"});
   // User-defined per-job options
-  // expected_command.insert(
-  //     expected_command.end(),
-  //     {"-Xmx1g", "-Xms500m", "-Dmy-job.hello=world", "-Dmy-job.foo=bar"});
+  expected_command.insert(
+      expected_command.end(),
+      {"-Xmx1g", "-Xms500m", "-Dmy-job.hello=world", "-Dmy-job.foo=bar"});
   // Ray-defined per-process options
-  // expected_command.push_back("-Dray.raylet.startup-token=0");
-  // expected_command.push_back("-Dray.internal.runtime-env-hash=1");
+  expected_command.push_back("-Dray.raylet.startup-token=0");
+  expected_command.push_back("-Dray.internal.runtime-env-hash=1");
   // User-defined per-process options
-  // expected_command.insert(
-  //     expected_command.end(), actor_jvm_options.begin(), actor_jvm_options.end());
+  expected_command.insert(
+      expected_command.end(), actor_jvm_options.begin(), actor_jvm_options.end());
   // Entry point
   expected_command.push_back("MainClass");
-  expected_command.push_back("--language=JULIA");
+  expected_command.push_back("--language=JAVA");
   ASSERT_EQ(real_command, expected_command);
   worker_pool_->HandleJobFinished(job_id);
 }
@@ -1383,10 +1383,10 @@ TEST_F(WorkerPoolDriverRegisteredTest, TestWorkerCappingWithExitDelay) {
   ///
 
   ///
-  /// Register some idle Python and Julia (w/ multi-worker enabled) workers
+  /// Register some idle Python and Java (w/ multi-worker enabled) workers
   ///
   std::vector<std::shared_ptr<WorkerInterface>> workers;
-  std::vector<Language> languages({Language::PYTHON, Language::JULIA});
+  std::vector<Language> languages({Language::PYTHON, Language::JAVA});
   for (int i = 0; i < POOL_SIZE_SOFT_LIMIT * 2; i++) {
     for (const auto &language : languages) {
       PopWorkerStatus status;
@@ -2098,9 +2098,9 @@ TEST_F(WorkerPoolTest, RegisterSecondPythonDriverCallbackImmediately) {
   ASSERT_TRUE(callback_called);
 }
 
-TEST_F(WorkerPoolTest, RegisterFirstJuliaDriverCallbackImmediately) {
+TEST_F(WorkerPoolTest, RegisterFirstJavaDriverCallbackImmediately) {
   auto driver =
-      worker_pool_->CreateWorker(Process::CreateNewDummy(), Language::JULIA, JOB_ID);
+      worker_pool_->CreateWorker(Process::CreateNewDummy(), Language::JAVA, JOB_ID);
 
   driver->AssignTaskId(TaskID::ForDriverTask(JOB_ID));
   bool callback_called = false;


### PR DESCRIPTION
Changes
* `src/raylet/main.cc` and `src/raylet/worker_pool.cc` adding support for Julia similarly to Java
* `ray/_private/services.py` & `ray/_private/context.py` implemented `julia_worker_command`

In a previous commit I modified the Raylet tests which passed so I assume the implementation is correct:
```sh
bazel build worker_pool_test
./bazel-bin/worker_pool_test
```

~~Note: I also noticed that for python you can `PrestartDefaultCpuWorkers`. I'm not sure in what context this happens but it sounds like this might be useful to do for Julia as well to cut down on latency of starting up workers.~~
We also discussed this and decided to forgo it to minimise risk of upstreaming these changes to the ray project.

<details><summary>Test output</summary>
<p>

```
[==========] Running 35 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 32 tests from WorkerPoolDriverRegisteredTest
[ RUN      ] WorkerPoolDriverRegisteredTest.CompareWorkerProcessObjects
[2023-08-07 15:08:29,378 I 76088 5542477] (worker_pool_test) agent_manager.cc:40: HandleRegisterAgent, ip: , port: 12345, id: 0
[       OK ] WorkerPoolDriverRegisteredTest.CompareWorkerProcessObjects (2 ms)
[ RUN      ] WorkerPoolDriverRegisteredTest.HandleWorkerRegistration
[2023-08-07 15:08:29,379 I 76088 5542477] (worker_pool_test) agent_manager.cc:40: HandleRegisterAgent, ip: , port: 12345, id: 0
[2023-08-07 15:08:29,380 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194305, the token is 0
[2023-08-07 15:08:29,380 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194306, the token is 1
[       OK ] WorkerPoolDriverRegisteredTest.HandleWorkerRegistration (1 ms)
[ RUN      ] WorkerPoolDriverRegisteredTest.HandleUnknownWorkerRegistration
[2023-08-07 15:08:29,381 I 76088 5542477] (worker_pool_test) agent_manager.cc:40: HandleRegisterAgent, ip: , port: 12345, id: 0
[2023-08-07 15:08:29,381 W 76088 5542477] (worker_pool_test) worker_pool.cc:736: Received a register request from an unknown token: -1
[       OK ] WorkerPoolDriverRegisteredTest.HandleUnknownWorkerRegistration (1 ms)
[ RUN      ] WorkerPoolDriverRegisteredTest.StartupPythonWorkerProcessCount
[2023-08-07 15:08:29,381 I 76088 5542477] (worker_pool_test) agent_manager.cc:40: HandleRegisterAgent, ip: , port: 12345, id: 0
[2023-08-07 15:08:29,381 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194305, the token is 0
[2023-08-07 15:08:29,381 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194306, the token is 1
[2023-08-07 15:08:29,381 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194307, the token is 2
[2023-08-07 15:08:29,381 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194308, the token is 3
[2023-08-07 15:08:29,381 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194309, the token is 4
[2023-08-07 15:08:29,381 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194310, the token is 5
[2023-08-07 15:08:29,381 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194311, the token is 6
[2023-08-07 15:08:29,381 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194312, the token is 7
[2023-08-07 15:08:29,381 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194313, the token is 8
[2023-08-07 15:08:29,381 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194314, the token is 9
[2023-08-07 15:08:29,381 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194315, the token is 10
[2023-08-07 15:08:29,381 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194316, the token is 11
[2023-08-07 15:08:29,381 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194317, the token is 12
[2023-08-07 15:08:29,381 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194318, the token is 13
[2023-08-07 15:08:29,381 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194319, the token is 14
[       OK ] WorkerPoolDriverRegisteredTest.StartupPythonWorkerProcessCount (1 ms)
[ RUN      ] WorkerPoolDriverRegisteredTest.StartupJuliaWorkerProcessCount
[2023-08-07 15:08:29,382 I 76088 5542477] (worker_pool_test) agent_manager.cc:40: HandleRegisterAgent, ip: , port: 12345, id: 0
[2023-08-07 15:08:29,382 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194305, the token is 0
[2023-08-07 15:08:29,382 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194306, the token is 1
[2023-08-07 15:08:29,382 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194307, the token is 2
[2023-08-07 15:08:29,382 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194308, the token is 3
[2023-08-07 15:08:29,382 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194309, the token is 4
[2023-08-07 15:08:29,382 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194310, the token is 5
[2023-08-07 15:08:29,382 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194311, the token is 6
[2023-08-07 15:08:29,382 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194312, the token is 7
[2023-08-07 15:08:29,382 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194313, the token is 8
[2023-08-07 15:08:29,382 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194314, the token is 9
[2023-08-07 15:08:29,382 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194315, the token is 10
[2023-08-07 15:08:29,382 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194316, the token is 11
[2023-08-07 15:08:29,382 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194317, the token is 12
[2023-08-07 15:08:29,382 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194318, the token is 13
[2023-08-07 15:08:29,382 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194319, the token is 14
[       OK ] WorkerPoolDriverRegisteredTest.StartupJuliaWorkerProcessCount (0 ms)
[ RUN      ] WorkerPoolDriverRegisteredTest.InitialWorkerProcessCount
[2023-08-07 15:08:29,382 I 76088 5542477] (worker_pool_test) agent_manager.cc:40: HandleRegisterAgent, ip: , port: 12345, id: 0
[       OK ] WorkerPoolDriverRegisteredTest.InitialWorkerProcessCount (1 ms)
[ RUN      ] WorkerPoolDriverRegisteredTest.TestPrestartingWorkers
[2023-08-07 15:08:29,383 I 76088 5542477] (worker_pool_test) agent_manager.cc:40: HandleRegisterAgent, ip: , port: 12345, id: 0
[2023-08-07 15:08:29,383 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194305, the token is 0
[2023-08-07 15:08:29,383 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194306, the token is 1
[2023-08-07 15:08:29,383 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194307, the token is 2
[2023-08-07 15:08:29,383 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194308, the token is 3
[2023-08-07 15:08:29,383 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194309, the token is 4
[       OK ] WorkerPoolDriverRegisteredTest.TestPrestartingWorkers (1 ms)
[ RUN      ] WorkerPoolDriverRegisteredTest.HandleWorkerPushPop
[2023-08-07 15:08:29,384 I 76088 5542477] (worker_pool_test) agent_manager.cc:40: HandleRegisterAgent, ip: , port: 12345, id: 0
[2023-08-07 15:08:29,384 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194305, the token is 0
[       OK ] WorkerPoolDriverRegisteredTest.HandleWorkerPushPop (0 ms)
[ RUN      ] WorkerPoolDriverRegisteredTest.PopWorkerSyncsOfMultipleLanguages
[2023-08-07 15:08:29,384 I 76088 5542477] (worker_pool_test) agent_manager.cc:40: HandleRegisterAgent, ip: , port: 12345, id: 0
[2023-08-07 15:08:29,384 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194305, the token is 0
[       OK ] WorkerPoolDriverRegisteredTest.PopWorkerSyncsOfMultipleLanguages (1 ms)
[ RUN      ] WorkerPoolDriverRegisteredTest.StartWorkerWithDynamicOptionsCommand
[2023-08-07 15:08:29,385 I 76088 5542477] (worker_pool_test) agent_manager.cc:40: HandleRegisterAgent, ip: , port: 12345, id: 0
[2023-08-07 15:08:29,385 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194305, the token is 0
[       OK ] WorkerPoolDriverRegisteredTest.StartWorkerWithDynamicOptionsCommand (0 ms)
[ RUN      ] WorkerPoolDriverRegisteredTest.PopWorkerMultiTenancy
[2023-08-07 15:08:29,385 I 76088 5542477] (worker_pool_test) agent_manager.cc:40: HandleRegisterAgent, ip: , port: 12345, id: 0
[       OK ] WorkerPoolDriverRegisteredTest.PopWorkerMultiTenancy (1 ms)
[ RUN      ] WorkerPoolDriverRegisteredTest.MaximumStartupConcurrency
[2023-08-07 15:08:29,386 I 76088 5542477] (worker_pool_test) agent_manager.cc:40: HandleRegisterAgent, ip: , port: 12345, id: 0
[2023-08-07 15:08:29,386 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194305, the token is 0
[2023-08-07 15:08:29,386 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194306, the token is 1
[2023-08-07 15:08:29,386 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194307, the token is 2
[2023-08-07 15:08:29,386 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194308, the token is 3
[2023-08-07 15:08:29,386 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194309, the token is 4
[2023-08-07 15:08:29,386 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194310, the token is 5
[2023-08-07 15:08:29,386 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194311, the token is 6
[2023-08-07 15:08:29,386 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194312, the token is 7
[2023-08-07 15:08:29,386 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194313, the token is 8
[2023-08-07 15:08:29,386 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194314, the token is 9
[2023-08-07 15:08:29,386 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194315, the token is 10
[2023-08-07 15:08:29,386 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194316, the token is 11
[2023-08-07 15:08:29,386 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194317, the token is 12
[2023-08-07 15:08:29,386 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194318, the token is 13
[2023-08-07 15:08:29,386 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194319, the token is 14
[2023-08-07 15:08:29,386 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194320, the token is 15
[2023-08-07 15:08:29,386 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194321, the token is 16
[       OK ] WorkerPoolDriverRegisteredTest.MaximumStartupConcurrency (1 ms)
[ RUN      ] WorkerPoolDriverRegisteredTest.HandleIOWorkersPushPop
[2023-08-07 15:08:29,387 I 76088 5542477] (worker_pool_test) agent_manager.cc:40: HandleRegisterAgent, ip: , port: 12345, id: 0
[2023-08-07 15:08:29,387 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194305, the token is 0
[2023-08-07 15:08:29,387 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194306, the token is 1
[2023-08-07 15:08:29,387 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194307, the token is 2
[2023-08-07 15:08:29,387 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194308, the token is 3
[2023-08-07 15:08:29,387 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194309, the token is 4
[2023-08-07 15:08:29,387 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194310, the token is 5
[2023-08-07 15:08:29,387 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194311, the token is 6
[2023-08-07 15:08:29,387 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194312, the token is 7
[       OK ] WorkerPoolDriverRegisteredTest.HandleIOWorkersPushPop (0 ms)
[ RUN      ] WorkerPoolDriverRegisteredTest.MaxIOWorkerSimpleTest
[2023-08-07 15:08:29,387 I 76088 5542477] (worker_pool_test) agent_manager.cc:40: HandleRegisterAgent, ip: , port: 12345, id: 0
[2023-08-07 15:08:29,387 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194305, the token is 0
[2023-08-07 15:08:29,387 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194306, the token is 1
[       OK ] WorkerPoolDriverRegisteredTest.MaxIOWorkerSimpleTest (0 ms)
[ RUN      ] WorkerPoolDriverRegisteredTest.MaxIOWorkerComplicateTest
[2023-08-07 15:08:29,387 I 76088 5542477] (worker_pool_test) agent_manager.cc:40: HandleRegisterAgent, ip: , port: 12345, id: 0
[2023-08-07 15:08:29,388 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194305, the token is 0
[2023-08-07 15:08:29,388 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194306, the token is 1
[       OK ] WorkerPoolDriverRegisteredTest.MaxIOWorkerComplicateTest (1 ms)
[ RUN      ] WorkerPoolDriverRegisteredTest.MaxSpillRestoreWorkersIntegrationTest
[2023-08-07 15:08:29,388 I 76088 5542477] (worker_pool_test) agent_manager.cc:40: HandleRegisterAgent, ip: , port: 12345, id: 0
[2023-08-07 15:08:29,388 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194305, the token is 0
[2023-08-07 15:08:29,388 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194306, the token is 1
[2023-08-07 15:08:29,388 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194307, the token is 2
[2023-08-07 15:08:29,388 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194308, the token is 3
[       OK ] WorkerPoolDriverRegisteredTest.MaxSpillRestoreWorkersIntegrationTest (0 ms)
[ RUN      ] WorkerPoolDriverRegisteredTest.DeleteWorkerPushPop
[2023-08-07 15:08:29,388 I 76088 5542477] (worker_pool_test) agent_manager.cc:40: HandleRegisterAgent, ip: , port: 12345, id: 0
[2023-08-07 15:08:29,388 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194305, the token is 0
[2023-08-07 15:08:29,388 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194306, the token is 1
[       OK ] WorkerPoolDriverRegisteredTest.DeleteWorkerPushPop (0 ms)
[ RUN      ] WorkerPoolDriverRegisteredTest.TestWorkerCapping
[2023-08-07 15:08:29,389 I 76088 5542477] (worker_pool_test) agent_manager.cc:40: HandleRegisterAgent, ip: , port: 12345, id: 0
[2023-08-07 15:08:29,389 I 76088 5542477] (worker_pool_test) worker_pool.cc:676: Job 01000000 already started in worker pool.
[2023-08-07 15:08:29,389 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194305, the token is 0
[2023-08-07 15:08:29,389 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194306, the token is 1
[2023-08-07 15:08:29,389 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194307, the token is 2
[2023-08-07 15:08:29,389 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194308, the token is 3
[2023-08-07 15:08:29,389 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194309, the token is 4
[2023-08-07 15:08:29,389 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194310, the token is 5
[2023-08-07 15:08:29,389 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194311, the token is 6
[2023-08-07 15:08:29,389 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194312, the token is 7
[2023-08-07 15:08:29,389 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194313, the token is 8
[       OK ] WorkerPoolDriverRegisteredTest.TestWorkerCapping (1 ms)
[ RUN      ] WorkerPoolDriverRegisteredTest.TestWorkerCappingLaterNWorkersNotOwningObjects
[2023-08-07 15:08:29,389 I 76088 5542477] (worker_pool_test) agent_manager.cc:40: HandleRegisterAgent, ip: , port: 12345, id: 0
[2023-08-07 15:08:29,389 I 76088 5542477] (worker_pool_test) worker_pool.cc:676: Job 01000000 already started in worker pool.
[2023-08-07 15:08:29,389 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194305, the token is 0
[2023-08-07 15:08:29,389 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194306, the token is 1
[2023-08-07 15:08:29,389 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194307, the token is 2
[2023-08-07 15:08:29,389 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194308, the token is 3
[2023-08-07 15:08:29,389 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194309, the token is 4
[2023-08-07 15:08:29,389 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194310, the token is 5
[2023-08-07 15:08:29,389 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194311, the token is 6
[2023-08-07 15:08:29,389 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194312, the token is 7
[2023-08-07 15:08:29,389 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194313, the token is 8
[2023-08-07 15:08:29,389 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194314, the token is 9
[       OK ] WorkerPoolDriverRegisteredTest.TestWorkerCappingLaterNWorkersNotOwningObjects (0 ms)
[ RUN      ] WorkerPoolDriverRegisteredTest.TestWorkerCappingWithExitDelay
[2023-08-07 15:08:29,389 I 76088 5542477] (worker_pool_test) agent_manager.cc:40: HandleRegisterAgent, ip: , port: 12345, id: 0
[2023-08-07 15:08:29,389 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194305, the token is 0
[2023-08-07 15:08:29,389 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194306, the token is 1
[2023-08-07 15:08:29,389 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194307, the token is 2
[2023-08-07 15:08:29,389 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194308, the token is 3
[2023-08-07 15:08:29,389 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194309, the token is 4
[2023-08-07 15:08:29,389 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194310, the token is 5
[2023-08-07 15:08:29,389 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194311, the token is 6
[2023-08-07 15:08:29,390 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194312, the token is 7
[2023-08-07 15:08:29,390 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194313, the token is 8
[2023-08-07 15:08:29,390 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194314, the token is 9
[2023-08-07 15:08:29,390 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194315, the token is 10
[2023-08-07 15:08:29,390 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194316, the token is 11
[2023-08-07 15:08:29,390 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194317, the token is 12
[2023-08-07 15:08:29,390 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194318, the token is 13
[2023-08-07 15:08:29,390 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194319, the token is 14
[2023-08-07 15:08:29,390 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194320, the token is 15
[2023-08-07 15:08:29,390 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194321, the token is 16
[2023-08-07 15:08:29,390 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194322, the token is 17
[2023-08-07 15:08:29,390 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194323, the token is 18
[2023-08-07 15:08:29,390 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194324, the token is 19
[       OK ] WorkerPoolDriverRegisteredTest.TestWorkerCappingWithExitDelay (1 ms)
[ RUN      ] WorkerPoolDriverRegisteredTest.TestJobFinishedForceKillIdleWorker
[2023-08-07 15:08:29,390 I 76088 5542477] (worker_pool_test) agent_manager.cc:40: HandleRegisterAgent, ip: , port: 12345, id: 0
[2023-08-07 15:08:29,390 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194305, the token is 0
[2023-08-07 15:08:29,390 I 76088 5542477] (worker_pool_test) worker_pool.cc:1104: Force exiting worker whose job has exited 0a5a1c87512b16b81c3c21287c7fd4fc6c2086ed559d44d07b762480
[       OK ] WorkerPoolDriverRegisteredTest.TestJobFinishedForceKillIdleWorker (0 ms)
[ RUN      ] WorkerPoolDriverRegisteredTest.WorkerFromAliveJobDoesNotBlockWorkerFromDeadJobFromGettingKilled
[2023-08-07 15:08:29,391 I 76088 5542477] (worker_pool_test) agent_manager.cc:40: HandleRegisterAgent, ip: , port: 12345, id: 0
[2023-08-07 15:08:29,391 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194305, the token is 0
[2023-08-07 15:08:29,391 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194306, the token is 1
[2023-08-07 15:08:29,391 I 76088 5542477] (worker_pool_test) worker_pool.cc:1104: Force exiting worker whose job has exited 304013456b215d747a2802b0c124fdc41acee8ac5c10646e8aa1beb8
[       OK ] WorkerPoolDriverRegisteredTest.WorkerFromAliveJobDoesNotBlockWorkerFromDeadJobFromGettingKilled (0 ms)
[ RUN      ] WorkerPoolDriverRegisteredTest.PopWorkerWithRuntimeEnv
[2023-08-07 15:08:29,391 I 76088 5542477] (worker_pool_test) agent_manager.cc:40: HandleRegisterAgent, ip: , port: 12345, id: 0
[2023-08-07 15:08:29,391 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194305, the token is 0
[2023-08-07 15:08:29,391 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194306, the token is 1
[2023-08-07 15:08:29,391 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194307, the token is 2
[       OK ] WorkerPoolDriverRegisteredTest.PopWorkerWithRuntimeEnv (0 ms)
[ RUN      ] WorkerPoolDriverRegisteredTest.RuntimeEnvUriReferenceJobLevel
[2023-08-07 15:08:29,392 I 76088 5542477] (worker_pool_test) agent_manager.cc:40: HandleRegisterAgent, ip: , port: 12345, id: 0
[2023-08-07 15:08:29,392 I 76088 5542477] (worker_pool_test) worker_pool.cc:686: [Eagerly] Start install runtime environment for job 39300000.
[2023-08-07 15:08:29,392 I 76088 5542477] (worker_pool_test) worker_pool.cc:697: [Eagerly] Create runtime env successful for job 39300000.
[       OK ] WorkerPoolDriverRegisteredTest.RuntimeEnvUriReferenceJobLevel (1 ms)
[ RUN      ] WorkerPoolDriverRegisteredTest.RuntimeEnvUriReferenceWorkerLevel
[2023-08-07 15:08:29,392 I 76088 5542477] (worker_pool_test) agent_manager.cc:40: HandleRegisterAgent, ip: , port: 12345, id: 0
[2023-08-07 15:08:29,392 I 76088 5542477] (worker_pool_test) worker_pool.cc:686: [Eagerly] Start install runtime environment for job 39300000.
[2023-08-07 15:08:29,392 I 76088 5542477] (worker_pool_test) worker_pool.cc:697: [Eagerly] Create runtime env successful for job 39300000.
[2023-08-07 15:08:29,392 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194305, the token is 0
[2023-08-07 15:08:29,392 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194306, the token is 1
[2023-08-07 15:08:29,392 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194307, the token is 2
[2023-08-07 15:08:29,392 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194308, the token is 3
[       OK ] WorkerPoolDriverRegisteredTest.RuntimeEnvUriReferenceWorkerLevel (0 ms)
[ RUN      ] WorkerPoolDriverRegisteredTest.CacheWorkersByRuntimeEnvHash
[2023-08-07 15:08:29,392 I 76088 5542477] (worker_pool_test) agent_manager.cc:40: HandleRegisterAgent, ip: , port: 12345, id: 0
[2023-08-07 15:08:29,392 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194305, the token is 0
[2023-08-07 15:08:29,392 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194306, the token is 1
[       OK ] WorkerPoolDriverRegisteredTest.CacheWorkersByRuntimeEnvHash (0 ms)
[ RUN      ] WorkerPoolDriverRegisteredTest.WorkerNoLeaks
[2023-08-07 15:08:29,392 I 76088 5542477] (worker_pool_test) agent_manager.cc:40: HandleRegisterAgent, ip: , port: 12345, id: 0
[2023-08-07 15:08:29,393 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194305, the token is 0
[       OK ] WorkerPoolDriverRegisteredTest.WorkerNoLeaks (1 ms)
[ RUN      ] WorkerPoolDriverRegisteredTest.PopWorkerStatus
[2023-08-07 15:08:29,393 I 76088 5542477] (worker_pool_test) agent_manager.cc:40: HandleRegisterAgent, ip: , port: 12345, id: 0
[2023-08-07 15:08:29,393 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194305, the token is 0
[2023-08-07 15:08:29,393 I 76088 5542477] (worker_pool_test) agent_manager.cc:254: Failed to create runtime env for job 7b000000, error message: bad runtime env
[2023-08-07 15:08:29,393 W 76088 5542477] (worker_pool_test) worker_pool.cc:1625: Couldn't create a runtime environment for job 7b000000.
[2023-08-07 15:08:29,393 W 76088 5542477] (worker_pool_test) worker_pool.cc:1296: Create runtime env failed for task 60830014407363f57c684563449e0340e22b6d3cffffffff and couldn't create the worker.
[2023-08-07 15:08:29,393 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194306, the token is 1
[2023-08-07 15:08:29,393 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194307, the token is 2
[2023-08-07 15:08:32,394 E 76088 5542635] (worker_pool_test) worker_pool.cc:548: Some workers of the worker process(4194307) have not registered within the timeout. The process is dead, probably it crashed during start.
[2023-08-07 15:08:32,394 E 76088 5542635] (worker_pool_test) worker_pool.cc:548: Some workers of the worker process(4194307) have not registered within the timeout. The process is dead, probably it crashed during start.
[       OK ] WorkerPoolDriverRegisteredTest.PopWorkerStatus (3002 ms)
[ RUN      ] WorkerPoolDriverRegisteredTest.TestIOWorkerFailureAndSpawn
[2023-08-07 15:08:32,395 I 76088 5542477] (worker_pool_test) agent_manager.cc:40: HandleRegisterAgent, ip: , port: 12345, id: 0
[2023-08-07 15:08:32,395 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194305, the token is 0
[2023-08-07 15:08:32,395 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194306, the token is 1
[2023-08-07 15:08:32,395 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194307, the token is 2
[2023-08-07 15:08:32,395 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194308, the token is 3
[2023-08-07 15:08:32,395 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194309, the token is 4
[2023-08-07 15:08:32,395 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194310, the token is 5
[2023-08-07 15:08:32,395 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194311, the token is 6
[       OK ] WorkerPoolDriverRegisteredTest.TestIOWorkerFailureAndSpawn (1 ms)
[ RUN      ] WorkerPoolDriverRegisteredTest.WorkerReuseForPrestartedWorker
[2023-08-07 15:08:32,396 I 76088 5542477] (worker_pool_test) agent_manager.cc:40: HandleRegisterAgent, ip: , port: 12345, id: 0
[2023-08-07 15:08:32,396 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194305, the token is 0
[       OK ] WorkerPoolDriverRegisteredTest.WorkerReuseForPrestartedWorker (0 ms)
[ RUN      ] WorkerPoolDriverRegisteredTest.WorkerReuseForSameJobId
[2023-08-07 15:08:32,397 I 76088 5542477] (worker_pool_test) agent_manager.cc:40: HandleRegisterAgent, ip: , port: 12345, id: 0
[2023-08-07 15:08:32,397 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194305, the token is 0
[       OK ] WorkerPoolDriverRegisteredTest.WorkerReuseForSameJobId (1 ms)
[ RUN      ] WorkerPoolDriverRegisteredTest.WorkerReuseFailureForDifferentJobId
[2023-08-07 15:08:32,397 I 76088 5542477] (worker_pool_test) agent_manager.cc:40: HandleRegisterAgent, ip: , port: 12345, id: 0
[2023-08-07 15:08:32,398 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194305, the token is 0
[2023-08-07 15:08:32,398 I 76088 5542477] (worker_pool_test) worker_pool.cc:493: Started worker process with pid 4194306, the token is 1
[       OK ] WorkerPoolDriverRegisteredTest.WorkerReuseFailureForDifferentJobId (1 ms)
[----------] 32 tests from WorkerPoolDriverRegisteredTest (3021 ms total)

[----------] 3 tests from WorkerPoolTest
[ RUN      ] WorkerPoolTest.RegisterFirstPythonDriverWaitForWorkerStart
[2023-08-07 15:08:32,398 I 76088 5542477] (worker_pool_test) agent_manager.cc:40: HandleRegisterAgent, ip: , port: 12345, id: 0
[       OK ] WorkerPoolTest.RegisterFirstPythonDriverWaitForWorkerStart (1 ms)
[ RUN      ] WorkerPoolTest.RegisterSecondPythonDriverCallbackImmediately
[2023-08-07 15:08:32,399 I 76088 5542477] (worker_pool_test) agent_manager.cc:40: HandleRegisterAgent, ip: , port: 12345, id: 0
[2023-08-07 15:08:32,399 I 76088 5542477] (worker_pool_test) worker_pool.cc:676: Job 01000000 already started in worker pool.
[       OK ] WorkerPoolTest.RegisterSecondPythonDriverCallbackImmediately (0 ms)
[ RUN      ] WorkerPoolTest.RegisterFirstJuliaDriverCallbackImmediately
[2023-08-07 15:08:32,400 I 76088 5542477] (worker_pool_test) agent_manager.cc:40: HandleRegisterAgent, ip: , port: 12345, id: 0
[       OK ] WorkerPoolTest.RegisterFirstJuliaDriverCallbackImmediately (1 ms)
[----------] 3 tests from WorkerPoolTest (2 ms total)

[----------] Global test environment tear-down
[==========] 35 tests from 2 test suites ran. (3023 ms total)
[  PASSED  ] 35 tests.
```

</p>
</details> 


I also ran the `ray_core_worker_julia_jll` demo (line-by-line) and the logs indicate that a julia driver was created as expected according to https://github.com/beacon-biosignals/ray_core_worker_julia_jll.jl/pull/14:
```
[state-dump] WorkerPool:
[state-dump] - registered jobs: 1
[state-dump] - process_failed_job_config_missing: 0
[state-dump] - process_failed_rate_limited: 0
[state-dump] - process_failed_pending_registration: 0
[state-dump] - process_failed_runtime_env_setup_failed: 0
[state-dump] - num PYTHON workers: 0
[state-dump] - num PYTHON drivers: 0
[state-dump] - num object spill callbacks queued: 0
[state-dump] - num object restore queued: 0
[state-dump] - num util functions queued: 0
[state-dump] - num CPP workers: 0
[state-dump] - num CPP drivers: 0
[state-dump] - num object spill callbacks queued: 0
[state-dump] - num object restore queued: 0
[state-dump] - num util functions queued: 0
[state-dump] - num JULIA workers: 0
[state-dump] - num JULIA drivers: 1
[state-dump] - num object spill callbacks queued: 0
[state-dump] - num object restore queued: 0
[state-dump] - num util functions queued: 0
[state-dump] - num idle workers: 0
```

<details><summary>session_latest/logs/debug_state.txt</summary>
<p>

```
NodeManager:
Node ID: eca10154c4bad3b348224d47b110c30211ed5611ad1fd9031f7e4c9b
Node name: 127.0.0.1
InitialConfigResources: {CPU: 80000, object_store_memory: 21474836480000, node:127.0.0.1: 10000, memory: 67484631040000}
ClusterTaskManager:
========== Node: eca10154c4bad3b348224d47b110c30211ed5611ad1fd9031f7e4c9b =================
Infeasible queue length: 0
Schedule queue length: 0
Dispatch queue length: 0
num_waiting_for_resource: 0
num_waiting_for_plasma_memory: 0
num_waiting_for_remote_node_resources: 0
num_worker_not_started_by_job_config_not_exist: 0
num_worker_not_started_by_registration_timeout: 0
num_tasks_waiting_for_workers: 0
num_cancelled_tasks: 0
cluster_resource_scheduler state: 
Local id: 6748723102786245840 Local resources: {memory: [67484631040000]/[67484631040000], object_store_memory: [21474836480000]/[21474836480000], node:127.0.0.1: [10000]/[10000], CPU: [80000]/[80000]}node id: 6748723102786245840{object_store_memory: 21474836480000/21474836480000, node:127.0.0.1: 10000/10000, CPU: 80000/80000, memory: 67484631040000/67484631040000}{ "placment group locations": [], "node to bundles": []}
Waiting tasks size: 0
Number of executing tasks: 0
Number of pinned task arguments: 0
Number of total spilled tasks: 0
Number of spilled waiting tasks: 0
Number of spilled unschedulable tasks: 0
Resource usage {
}
Running tasks by scheduling class:
==================================================

ClusterResources:
LocalObjectManager:
- num pinned objects: 0
- pinned objects size: 0
- num objects pending restore: 0
- num objects pending spill: 0
- num bytes pending spill: 0
- num bytes currently spilled: 0
- cumulative spill requests: 0
- cumulative restore requests: 0
- spilled objects pending delete: 0

ObjectManager:
- num local objects: 0
- num unfulfilled push requests: 0
- num object pull requests: 0
- num chunks received total: 0
- num chunks received failed (all): 0
- num chunks received failed / cancelled: 0
- num chunks received failed / plasma error: 0
Event stats:
Global stats: 1 total (0 active)
Queueing time: mean = 37.000 us, max = 37.000 us, min = 37.000 us, total = 37.000 us
Execution time:  mean = 8.000 us, total = 8.000 us
Event stats:
	ObjectManager.FreeObjects - 1 total (0 active), CPU time: mean = 8.000 us, total = 8.000 us
PushManager:
- num pushes in flight: 0
- num chunks in flight: 0
- num chunks remaining: 0
- max chunks allowed: 409
OwnershipBasedObjectDirectory:
- num listeners: 0
- cumulative location updates: 0
- num location updates per second: 0.000
- num location lookups per second: 0.000
- num locations added per second: 0.000
- num locations removed per second: 0.200
BufferPool:
- create buffer state map size: 0
PullManager:
- num bytes available for pulled objects: 2147483648
- num bytes being pulled (all): 0
- num bytes being pulled / pinned: 0
- get request bundles: BundlePullRequestQueue{0 total, 0 active, 0 inactive, 0 unpullable}
- wait request bundles: BundlePullRequestQueue{0 total, 0 active, 0 inactive, 0 unpullable}
- task request bundles: BundlePullRequestQueue{0 total, 0 active, 0 inactive, 0 unpullable}
- first get request bundle: N/A
- first wait request bundle: N/A
- first task request bundle: N/A
- num objects queued: 0
- num objects actively pulled (all): 0
- num objects actively pulled / pinned: 0
- num bundles being pulled: 0
- num pull retries: 0
- max timeout seconds: 0
- max timeout request is already processed. No entry.

WorkerPool:
- registered jobs: 0
- process_failed_job_config_missing: 0
- process_failed_rate_limited: 0
- process_failed_pending_registration: 0
- process_failed_runtime_env_setup_failed: 0
- num PYTHON workers: 0
- num PYTHON drivers: 0
- num object spill callbacks queued: 0
- num object restore queued: 0
- num util functions queued: 0
- num CPP workers: 0
- num CPP drivers: 0
- num object spill callbacks queued: 0
- num object restore queued: 0
- num util functions queued: 0
- num JULIA workers: 0
- num JULIA drivers: 0
- num object spill callbacks queued: 0
- num object restore queued: 0
- num util functions queued: 0
- num idle workers: 0
TaskDependencyManager:
- task deps map size: 0
- get req map size: 0
- wait req map size: 0
- local objects map size: 0
WaitManager:
- num active wait requests: 0
Subscriber:
Channel WORKER_OBJECT_EVICTION
- cumulative subscribe requests: 1
- cumulative unsubscribe requests: 1
- active subscribed publishers: 0
- cumulative published messages: 0
- cumulative processed messages: 0
Channel WORKER_REF_REMOVED_CHANNEL
- cumulative subscribe requests: 0
- cumulative unsubscribe requests: 0
- active subscribed publishers: 0
- cumulative published messages: 0
- cumulative processed messages: 0
Channel WORKER_OBJECT_LOCATIONS_CHANNEL
- cumulative subscribe requests: 1
- cumulative unsubscribe requests: 1
- active subscribed publishers: 0
- cumulative published messages: 0
- cumulative processed messages: 0
num async plasma notifications: 0
Remote node managers: 
Event stats:
Global stats: 5575 total (12 active)
Queueing time: mean = 14.589 ms, max = 67.146 s, min = 0.000 ns, total = 81.331 s
Execution time:  mean = 15.772 us, total = 87.929 ms
Event stats:
	UNKNOWN - 1577 total (4 active), CPU time: mean = 8.068 us, total = 12.724 ms
	NodeManager.CheckGC - 1389 total (1 active), CPU time: mean = 3.270 us, total = 4.542 ms
	ObjectManager.UpdateAvailableMemory - 1388 total (0 active), CPU time: mean = 2.351 us, total = 3.263 ms
	RayletWorkerPool.deadline_timer.kill_idle_workers - 698 total (1 active), CPU time: mean = 11.350 us, total = 7.922 ms
	NodeManager.deadline_timer.flush_free_objects - 140 total (1 active), CPU time: mean = 8.250 us, total = 1.155 ms
	NodeManagerService.grpc_server.GetResourceLoad - 140 total (0 active), CPU time: mean = 45.029 us, total = 6.304 ms
	NodeManagerService.grpc_server.ReportWorkerBacklog - 79 total (0 active), CPU time: mean = 37.823 us, total = 2.988 ms
	NodeManager.GcsCheckAlive - 28 total (1 active), CPU time: mean = 229.964 us, total = 6.439 ms
	NodeManager.deadline_timer.record_metrics - 28 total (1 active), CPU time: mean = 315.143 us, total = 8.824 ms
	NodeInfoGcsService.grpc_client.CheckAlive - 28 total (0 active), CPU time: mean = 21.964 us, total = 615.000 us
	NodeManager.deadline_timer.debug_state_dump - 14 total (1 active, 1 running), CPU time: mean = 1.353 ms, total = 18.946 ms
	ClientConnection.async_read.ReadBufferAsync - 12 total (0 active), CPU time: mean = 80.333 us, total = 964.000 us
	PeriodicalRunner.RunFnPeriodically - 11 total (0 active), CPU time: mean = 146.182 us, total = 1.608 ms
	InternalPubSubGcsService.grpc_client.GcsSubscriberPoll - 4 total (1 active), CPU time: mean = 60.500 us, total = 242.000 us
	RaySyncer.BroadcastMessage - 3 total (0 active), CPU time: mean = 98.333 us, total = 295.000 us
	NodeManager.deadline_timer.print_event_loop_stats - 3 total (1 active), CPU time: mean = 995.333 us, total = 2.986 ms
	CoreWorkerService.grpc_client.PubsubCommandBatch - 3 total (0 active), CPU time: mean = 117.333 us, total = 352.000 us
	 - 3 total (0 active), CPU time: mean = 0.000 ns, total = 0.000 ns
	ObjectManager.ObjectDeleted - 2 total (0 active), CPU time: mean = 367.500 us, total = 735.000 us
	ObjectManager.ObjectAdded - 2 total (0 active), CPU time: mean = 233.500 us, total = 467.000 us
	CoreWorkerService.grpc_client.UpdateObjectLocationBatch - 2 total (0 active), CPU time: mean = 67.500 us, total = 135.000 us
	CoreWorkerService.grpc_client.PubsubLongPolling - 2 total (0 active), CPU time: mean = 57.500 us, total = 115.000 us
	Subscriber.HandlePublishedMessage_GCS_JOB_CHANNEL - 2 total (0 active), CPU time: mean = 64.000 us, total = 128.000 us
	RaySyncerRegister - 2 total (0 active), CPU time: mean = 500.000 ns, total = 1.000 us
	InternalPubSubGcsService.grpc_client.GcsSubscriberCommandBatch - 2 total (0 active), CPU time: mean = 54.500 us, total = 109.000 us
	NodeInfoGcsService.grpc_client.RegisterNode - 1 total (0 active), CPU time: mean = 106.000 us, total = 106.000 us
	NodeManagerService.grpc_server.PinObjectIDs - 1 total (0 active), CPU time: mean = 196.000 us, total = 196.000 us
	NodeManagerService.grpc_server.GetSystemConfig - 1 total (0 active), CPU time: mean = 19.000 us, total = 19.000 us
	JobInfoGcsService.grpc_client.MarkJobFinished - 1 total (0 active), CPU time: mean = 12.000 us, total = 12.000 us
	JobInfoGcsService.grpc_client.GetAllJobInfo - 1 total (0 active), CPU time: mean = 5.000 us, total = 5.000 us
	JobInfoGcsService.grpc_client.AddJob - 1 total (0 active), CPU time: mean = 15.000 us, total = 15.000 us
	ClientConnection.async_write.DoAsyncWrites - 1 total (0 active), CPU time: mean = 1.000 us, total = 1.000 us
	AgentManagerService.grpc_server.RegisterAgent - 1 total (0 active), CPU time: mean = 104.000 us, total = 104.000 us
	WorkerInfoGcsService.grpc_client.ReportWorkerFailure - 1 total (0 active), CPU time: mean = 7.000 us, total = 7.000 us
	NodeInfoGcsService.grpc_client.GetAllNodeInfo - 1 total (0 active), CPU time: mean = 64.000 us, total = 64.000 us
	Subscriber.HandleFailureCallback_WORKER_OBJECT_EVICTION - 1 total (0 active), CPU time: mean = 25.000 us, total = 25.000 us
	NodeInfoGcsService.grpc_client.GetInternalConfig - 1 total (0 active), CPU time: mean = 5.511 ms, total = 5.511 ms
	Subscriber.HandlePublishedMessage_GCS_WORKER_DELTA_CHANNEL - 1 total (0 active), CPU time: mean = 5.000 us, total = 5.000 us
DebugString() time ms: 1
```

</p>
</details> 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205187707545685