### PR TITLE
Support JuliaFunctionDescriptor in `==` fallback

### DIFF
--- a/src/ray/common/function_descriptor.h
+++ b/src/ray/common/function_descriptor.h
@@ -358,6 +358,9 @@ inline bool operator==(const FunctionDescriptor &left, const FunctionDescriptor 
   case ray::FunctionDescriptorType::kCppFunctionDescriptor:
     return static_cast<const CppFunctionDescriptor &>(*left) ==
            static_cast<const CppFunctionDescriptor &>(*right);
+  case ray::FunctionDescriptorType::kJuliaFunctionDescriptor:
+    return static_cast<const JuliaFunctionDescriptor &>(*left) ==
+           static_cast<const JuliaFunctionDescriptor &>(*right);
   default:
     RAY_LOG(FATAL) << "Unknown function descriptor type: " << left->Type();
     return false;


### PR DESCRIPTION
Follow up to #1. Addresses this issue:
```
[2023-08-09 11:34:45,601 C 18606 701723] function_descriptor.h:362: Unknown function descriptor type: 4
*** StackTrace Information ***
0   julia_core_worker_lib.so            0x00000001263a50d0 _ZN3raylsERNSt3__113basic_ostreamIcNS0_11char_traitsIcEEEERKNS_10StackTraceE + 84 ray::operator<<()
1   julia_core_worker_lib.so            0x00000001263d2620 _ZN3ray13SpdLogMessage5FlushEv + 220 ray::SpdLogMessage::Flush()
2   julia_core_worker_lib.so            0x00000001263d24a0 _ZN3ray13SpdLogMessageD2Ev + 24 ray::SpdLogMessage::~SpdLogMessage()
3   julia_core_worker_lib.so            0x00000001263a8164 _ZN3ray6RayLogD2Ev + 52 ray::RayLog::~RayLog()
4   julia_core_worker_lib.so            0x00000001263883c0 _ZN3rayeqERKNSt3__110shared_ptrINS_27FunctionDescriptorInterfaceEEES5_ + 248 ray::operator==()
```