### PR TITLE
pass `--startup_token` to julia worker

### DIFF
--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -331,7 +331,7 @@ WorkerPool::BuildProcessCommandArgs(const Language &language,
                                   std::to_string(worker_startup_token_counter_));
     worker_command_args.push_back("--worker-launch-time-ms=" +
                                   std::to_string(current_sys_time_ms()));
-  } else if (language == Language::CPP) {
+  } else if (language == Language::CPP || language == Language::JULIA) {
     worker_command_args.push_back("--startup_token=" +
                                   std::to_string(worker_startup_token_counter_));
   }


### PR DESCRIPTION
I think this is needed to enable multiple workers to start 😬 

https://github.com/beacon-biosignals/ray_core_worker_julia_jll.jl/issues/30