### PR TITLE
Runtime environment can specify Julia executable and arguments

### DIFF
--- a/dashboard/modules/runtime_env/runtime_env_agent.py
+++ b/dashboard/modules/runtime_env/runtime_env_agent.py
@@ -290,6 +290,7 @@ class RuntimeEnvAgent(
             per_job_logger.debug(f"Worker has resource :" f"{allocated_resource}")
             context = RuntimeEnvContext(
                 env_vars=runtime_env.env_vars(),
+                # TODO: use plugin instead of special casing
                 julia_command=runtime_env.julia_command(),
             )
             await self._container_manager.setup(

--- a/dashboard/modules/runtime_env/runtime_env_agent.py
+++ b/dashboard/modules/runtime_env/runtime_env_agent.py
@@ -289,9 +289,8 @@ class RuntimeEnvAgent(
             # avoid lint error. That will be moved to cgroup plugin.
             per_job_logger.debug(f"Worker has resource :" f"{allocated_resource}")
             context = RuntimeEnvContext(
-                executable=runtime_env.executable(),
-                args=runtime_env.args(),
                 env_vars=runtime_env.env_vars(),
+                command=runtime_env.command(),
             )
             await self._container_manager.setup(
                 runtime_env, context, logger=per_job_logger

--- a/dashboard/modules/runtime_env/runtime_env_agent.py
+++ b/dashboard/modules/runtime_env/runtime_env_agent.py
@@ -290,7 +290,7 @@ class RuntimeEnvAgent(
             per_job_logger.debug(f"Worker has resource :" f"{allocated_resource}")
             context = RuntimeEnvContext(
                 env_vars=runtime_env.env_vars(),
-                command=runtime_env.command(),
+                julia_command=runtime_env.julia_command(),
             )
             await self._container_manager.setup(
                 runtime_env, context, logger=per_job_logger

--- a/dashboard/modules/runtime_env/runtime_env_agent.py
+++ b/dashboard/modules/runtime_env/runtime_env_agent.py
@@ -288,7 +288,11 @@ class RuntimeEnvAgent(
             # TODO(chenk008): Add log about allocated_resource to
             # avoid lint error. That will be moved to cgroup plugin.
             per_job_logger.debug(f"Worker has resource :" f"{allocated_resource}")
-            context = RuntimeEnvContext(env_vars=runtime_env.env_vars())
+            context = RuntimeEnvContext(
+                executable=runtime_env.executable(),
+                args=runtime_env.args(),
+                env_vars=runtime_env.env_vars(),
+            )
             await self._container_manager.setup(
                 runtime_env, context, logger=per_job_logger
             )

--- a/python/ray/_private/runtime_env/context.py
+++ b/python/ray/_private/runtime_env/context.py
@@ -74,6 +74,7 @@ class RuntimeEnvContext:
             executable = self.executable or "julia"
             args = self.args or ["-e", "'using Ray; start_worker()'"]
             args += ["--"]
+            args = [f"'{s}'" if " " in s else s for s in args]
             # TODO(omus): required to avoid bash interpreting Julia code.
             executable = " ".join([executable] + args)
         elif sys.platform == "win32":
@@ -81,6 +82,8 @@ class RuntimeEnvContext:
         else:
             executable = "exec "
 
+        # TODO(omus): arguments in the `command_str` should be escaped to avoid
+        # any bash interpretation
         passthrough_args = [s.replace(" ", r"\ ") for s in passthrough_args]
         exec_command = " ".join([f"{executable}"] + passthrough_args)
         command_str = " ".join(self.command_prefix + [exec_command])

--- a/python/ray/_private/runtime_env/context.py
+++ b/python/ray/_private/runtime_env/context.py
@@ -72,7 +72,7 @@ class RuntimeEnvContext:
             passthrough_args = class_path_args + passthrough_args
         elif language == Language.JULIA:
             executable = self.executable or "julia"
-            args = self.args or ["-e", "'using Ray; start_worker()'"]
+            args = self.args or ["-e", "using Ray; start_worker()"]
             args += ["--"]
             args = [f"'{s}'" if " " in s else s for s in args]
             # TODO(omus): required to avoid bash interpreting Julia code.

--- a/python/ray/runtime_env/runtime_env.py
+++ b/python/ray/runtime_env/runtime_env.py
@@ -254,6 +254,8 @@ class RuntimeEnv(dict):
         "container",
         "excludes",
         "env_vars",
+        "executable",
+        "args",
         "_ray_release",
         "_ray_commit",
         "_inject_current_ray",
@@ -281,6 +283,8 @@ class RuntimeEnv(dict):
         conda: Optional[Union[Dict[str, str], str]] = None,
         container: Optional[Dict[str, str]] = None,
         env_vars: Optional[Dict[str, str]] = None,
+        executable: Optional[str] = None,
+        args: Optional[List[str]] = None,
         worker_setup_hook: Optional[Union[Callable, str]] = None,
         config: Optional[Union[Dict, RuntimeEnvConfig]] = None,
         _validate: bool = True,
@@ -301,6 +305,10 @@ class RuntimeEnv(dict):
             runtime_env["container"] = container
         if env_vars is not None:
             runtime_env["env_vars"] = env_vars
+        if executable is not None:
+            runtime_env["executable"] = executable
+        if args is not None:
+            runtime_env["args"] = args
         if config is not None:
             runtime_env["config"] = config
         if worker_setup_hook is not None:
@@ -437,6 +445,14 @@ class RuntimeEnv(dict):
     def java_jars(self) -> List[str]:
         if "java_jars" in self:
             return list(self["java_jars"])
+        return []
+
+    def executable(self) -> str:
+        return self.get("executable", "")
+
+    def args(self) -> List[str]:
+        if "args" in self:
+            return list(self["args"])
         return []
 
     def env_vars(self) -> Dict:

--- a/python/ray/runtime_env/runtime_env.py
+++ b/python/ray/runtime_env/runtime_env.py
@@ -254,7 +254,7 @@ class RuntimeEnv(dict):
         "container",
         "excludes",
         "env_vars",
-        "command",
+        "julia_command",
         "_ray_release",
         "_ray_commit",
         "_inject_current_ray",
@@ -282,7 +282,6 @@ class RuntimeEnv(dict):
         conda: Optional[Union[Dict[str, str], str]] = None,
         container: Optional[Dict[str, str]] = None,
         env_vars: Optional[Dict[str, str]] = None,
-        command: Optional[List[str]] = None,
         worker_setup_hook: Optional[Union[Callable, str]] = None,
         config: Optional[Union[Dict, RuntimeEnvConfig]] = None,
         _validate: bool = True,
@@ -303,8 +302,6 @@ class RuntimeEnv(dict):
             runtime_env["container"] = container
         if env_vars is not None:
             runtime_env["env_vars"] = env_vars
-        if command is not None:
-            runtime_env["command"] = command
         if config is not None:
             runtime_env["config"] = config
         if worker_setup_hook is not None:
@@ -312,6 +309,8 @@ class RuntimeEnv(dict):
 
         if runtime_env.get("java_jars"):
             runtime_env["java_jars"] = runtime_env.get("java_jars")
+        if runtime_env.get("julia_command"):
+            runtime_env["julia_command"] = runtime_env.get("julia_command")
 
         self.update(runtime_env)
 
@@ -446,9 +445,9 @@ class RuntimeEnv(dict):
     def env_vars(self) -> Dict:
         return self.get("env_vars", {})
 
-    def command(self) -> List[str]:
-        if "command" in self:
-            return list(self["command"])
+    def julia_command(self) -> List[str]:
+        if "julia_command" in self:
+            return list(self["julia_command"])
         return []
 
     def has_conda(self) -> str:

--- a/python/ray/runtime_env/runtime_env.py
+++ b/python/ray/runtime_env/runtime_env.py
@@ -254,8 +254,7 @@ class RuntimeEnv(dict):
         "container",
         "excludes",
         "env_vars",
-        "executable",
-        "args",
+        "command",
         "_ray_release",
         "_ray_commit",
         "_inject_current_ray",
@@ -283,8 +282,7 @@ class RuntimeEnv(dict):
         conda: Optional[Union[Dict[str, str], str]] = None,
         container: Optional[Dict[str, str]] = None,
         env_vars: Optional[Dict[str, str]] = None,
-        executable: Optional[str] = None,
-        args: Optional[List[str]] = None,
+        command: Optional[List[str]] = None,
         worker_setup_hook: Optional[Union[Callable, str]] = None,
         config: Optional[Union[Dict, RuntimeEnvConfig]] = None,
         _validate: bool = True,
@@ -305,10 +303,8 @@ class RuntimeEnv(dict):
             runtime_env["container"] = container
         if env_vars is not None:
             runtime_env["env_vars"] = env_vars
-        if executable is not None:
-            runtime_env["executable"] = executable
-        if args is not None:
-            runtime_env["args"] = args
+        if command is not None:
+            runtime_env["command"] = command
         if config is not None:
             runtime_env["config"] = config
         if worker_setup_hook is not None:
@@ -447,16 +443,13 @@ class RuntimeEnv(dict):
             return list(self["java_jars"])
         return []
 
-    def executable(self) -> str:
-        return self.get("executable", "")
-
-    def args(self) -> List[str]:
-        if "args" in self:
-            return list(self["args"])
-        return []
-
     def env_vars(self) -> Dict:
         return self.get("env_vars", {})
+
+    def command(self) -> List[str]:
+        if "command" in self:
+            return list(self["command"])
+        return []
 
     def has_conda(self) -> str:
         if self.get("conda"):


### PR DESCRIPTION
Working on https://github.com/beacon-biosignals/Ray.jl/issues/103.

Something tricky about getting this to work was that I found that my `serialized_runtime_env` was set properly [here](https://github.com/ray-project/ray/blob/a03efd9931128d387649dd48b0e4864b43d3bfb4/src/ray/raylet/agent_manager.cc#L236) but the [RPC reply later](https://github.com/ray-project/ray/blob/a03efd9931128d387649dd48b0e4864b43d3bfb4/src/ray/raylet/agent_manager.cc#L251) had filtered out my new parameters. I wasn't sure where this was being processed so I [removed `env_vars` from the `RuntimeEnvContext`](https://github.com/ray-project/ray/blob/a03efd9931128d387649dd48b0e4864b43d3bfb4/python/ray/_private/runtime_env/context.py#L30) and got a stack trace which pointed me to the dashboard code. It turns out that you need to pass through any runtime environment information [here](https://github.com/ray-project/ray/blob/a03efd9931128d387649dd48b0e4864b43d3bfb4/dashboard/modules/runtime_env/runtime_env_agent.py#L291) or it will be expected to be processed by a plugin. If no plugin is associated with the key then the value is just set to the default in `RuntimeEnvContext`.