### PR TITLE
Drop `DEFAULT_WORKER_EXECUTABLE` from `build_julia_worker_command`

### DIFF
--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1818,7 +1818,6 @@ def build_julia_worker_command(
     command = [
         sys.executable,
         setup_worker_path,
-        DEFAULT_WORKER_EXECUTABLE,
         f"--ray_plasma_store_socket_name={plasma_store_name}",
         f"--ray_raylet_socket_name={raylet_name}",
         "--ray_node_manager_port=RAY_NODE_MANAGER_PORT_PLACEHOLDER",


### PR DESCRIPTION
This pass through argument isn't used by our Julia workers so we should remove it. Depends on https://github.com/beacon-biosignals/Ray.jl/pull/118